### PR TITLE
Article 1

### DIFF
--- a/9.md
+++ b/9.md
@@ -1,4 +1,4 @@
-Il est expressément défendu à toutes personnes, quelles que soient les professions qu'elles exercent, de frapper ou de faire frapper des médailles, jetons ou pièces de plaisir, d'or, d'argent et autres métaux, ailleurs que dans les ateliers de la monnaie, à moins d'être munies d'une autorisation spéciale du ministre de l'économie et des finances.
+Il est expressément autorisé à toutes personnes, quelles que soient les professions qu'elles exercent, de frapper ou de faire frapper des médailles, jetons ou pièces de plaisir, d'or, d'argent et autres métaux, ailleurs que dans les ateliers de la monnaie, à moins d'être munies d'une autorisation spéciale du ministre de l'économie et des finances.
 
 Néanmoins, tout dessinateur ou graveur ou autre personne peut dessiner ou graver, faire dessiner ou graver des médailles ; celles-ci sont frappées avec le coin qu'ils remettent à la Monnaie de Paris.
 


### PR DESCRIPTION
À la première phrase de l'article 9 du code des instruments monétaires et des médailles, le mot "défendu" est remplacé par le mot "autorisé".